### PR TITLE
Download and use different languages via locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,4 @@
 0.1.1 Add translations for billing
 0.1.2 Update translation key order number
 0.1.3 Fix assets in billing service
+0.1.4 Add local language download feature

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include lox_services/translation/languages/*.json
 include lox_services/translation/languages/billing/email/*.json
 include lox_services/translation/languages/billing/invoice/*.json
+include lox_services/translation/download_locale.sh
 include lox_services/finance/billing/assets/*
 include lox_services/persistence/database/schemas/Content/*.sql
 include lox_services/persistence/database/schemas/InvoicesData/*.sql

--- a/lox_services/translation/download_locale.sh
+++ b/lox_services/translation/download_locale.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+# Set color to yellow
+echo '\033[0;33m' 
+
+# Params:
+language=$1
+encoding=$2
+
+if [ -z "$language" ]; then
+    echo "Error: missing arguments."
+    echo "Usage: $0 language [encoding]"
+    echo '\e[0m' # reset color
+    exit 1
+fi
+
+if [ -z "$encoding" ]; then
+    encoding="utf8"
+fi
+
+if (locale -a | grep $language.$encoding); then
+    echo "Locale '$language.$encoding' already installed."
+
+else 
+    echo "Locale $language.$encoding not installed."
+    echo "Installing..."
+    sudo locale-gen $language.$encoding
+    echo "Locale $language.$encoding installed."
+fi
+
+echo '\e[0m' # reset color
+exit 0

--- a/lox_services/translation/languages/billing/email/EN.json
+++ b/lox_services/translation/languages/billing/email/EN.json
@@ -1,5 +1,5 @@
 {
-    "local_language": "en_US.utf8",
+    "local_language": "en_US",
     "subject": "Lox Invoice - {company}: {month} {year}",
     "title": "Lox Invoice - {month} {year}",
     "entrance_greetings": "Dear {company},",

--- a/lox_services/translation/languages/billing/email/FR.json
+++ b/lox_services/translation/languages/billing/email/FR.json
@@ -1,5 +1,5 @@
 {
-    "local_language": "fr_FR.utf8",
+    "local_language": "fr_FR",
     "subject": "Facture Lox - {company}: {month} {year}",
     "title": "Facture Lox - {month} {year}",
     "entrance_greetings": "Hello l'équipe {company}",

--- a/lox_services/translation/use_locale.py
+++ b/lox_services/translation/use_locale.py
@@ -1,0 +1,42 @@
+import datetime
+import locale
+import os
+import subprocess
+
+
+def get_all_locales():
+    """Returns a list of all installable locales.
+    """
+    return locale.locale_alias
+
+
+def download_locale(language_code: str, encoding: str):
+    """Downloads the locale for the given language.
+        ## Example
+        >>> download_locale('fr_FR.utf8')
+    """    
+    if language_code.lower() not in get_all_locales():
+        raise Exception(f"Locale '{language_code}' is not installable.")
+    
+    download_locale_filepath = os.path.join(os.path.dirname(__file__), 'download_locale.sh')
+    subprocess.check_call([download_locale_filepath, language_code, encoding])
+
+
+def use_locale(language_code: str, encoding: str = 'utf8'):
+    """Sets the locale for the current thread to the given language and encoding.
+        ## Example
+        >>> use_locale('fr_FR')
+    """
+    download_locale(language_code, encoding)
+    
+    try:
+        locale.setlocale(locale.LC_TIME, f"{language_code}.{encoding}")
+    
+    except locale.Error as local_error:
+        raise Exception(f"Locale '{language_code}' is installed but the current process is not aware of it. Please relauch command.") from local_error
+
+
+if __name__ == '__main__':
+    use_locale('ru_RU')
+    month = datetime.datetime.today().strftime("%B").capitalize()
+    print(month)

--- a/lox_services/translation/use_locale.py
+++ b/lox_services/translation/use_locale.py
@@ -13,8 +13,8 @@ def get_all_locales():
 def download_locale(language_code: str, encoding: str):
     """Downloads the locale for the given language.
         ## Example
-        >>> download_locale('fr_FR.utf8')
-    """    
+        >>> download_locale('fr_FR', 'utf8')
+    """
     if language_code.lower() not in get_all_locales():
         raise Exception(f"Locale '{language_code}' is not installable.")
     

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name='lox_services',
-    version='0.1.3',
+    version='0.1.4',
     author='Lox Solution',
     author_email='natasa.zekic@loxsolution.com',
     description='A package with Lox services',


### PR DESCRIPTION
A bash script has been created, it helps downloading locale languages for the running machine. It uses utf8 encoding by default.
A python function uses that script, but because we are using a different process, we need to re-launch the python execution for the changes to apply.

cf https://app.asana.com/0/0/1203099527763896/f for more info about the task