### PR TITLE
A currency converter helper utility for pandas dataframes.

### DIFF
--- a/lox_services/utils/convert_currencies.py
+++ b/lox_services/utils/convert_currencies.py
@@ -1,0 +1,31 @@
+from typing import Final
+
+import numpy as np
+import numpy.typing as npt
+import pandas as pd
+from currency_converter import ECB_URL, CurrencyConverter
+
+CURRENCY: Final = CurrencyConverter(
+    ECB_URL,
+    fallback_on_missing_rate=True,
+    fallback_on_missing_rate_method="last_known",  # NOQA
+    fallback_on_wrong_date=True,
+)
+
+
+def column_to_euro(
+    amount_col: pd.Series, currency_col: pd.Series, date_col: pd.Series
+) -> npt.NDArray[np.float32]:
+    """Given relevant columns, convert local currency values to euro row-wise."""
+
+    arr = np.array(
+        [
+            CURRENCY.convert(col1, col2, "EUR", date=col3)
+            for col1, col2, col3 in zip(
+                amount_col.astype(float),
+                currency_col,
+                date_col,
+            )
+        ]
+    )
+    return np.round(arr, 2)


### PR DESCRIPTION
Here is a helper utility function to convert a pandas column from their own currency values to Euro, utilizing currencyconverter PyPi package and time-sensitive data from the European Central Bank archive. Current list comprehension approach [should be quite efficient](https://stackoverflow.com/a/54432584), though there is space for [further performance gain](https://pandas.pydata.org/docs/user_guide/enhancingperf.html#numba-jit-compilation) with just-in-time compilation if needed.