### PR TITLE
Add an optional argument for SQL parameterization to "select" function.

### DIFF
--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -1,6 +1,9 @@
 import os
 import unittest
 import datetime
+
+import pandas as pd
+
 from lox_services.utils.decorators import Perf
 
 from lox_services.utils.general_python import (
@@ -15,48 +18,51 @@ from lox_services.utils.general_python import (
     split_array,
     split_date_range)
 
-
 PDF_ASSETS_PATH = os.path.join(os.path.dirname(__file__), os.pardir, os.pardir, "lox_services", "pdf", "assets")
 file_path = os.path.join(PDF_ASSETS_PATH, 'pdf_tables.css')
 
+
 class Test_files_and_folders_functions(unittest.TestCase):
-    
+
     def test_is_file_or_folder_path(self):
-        self.assertEqual(is_file_or_folder_path(file_path),'file')
-        self.assertNotEqual(is_file_or_folder_path(file_path),'folder')
-        self.assertEqual(is_file_or_folder_path(PDF_ASSETS_PATH),'folder')
-        self.assertNotEqual(is_file_or_folder_path(PDF_ASSETS_PATH),'file')
+        self.assertEqual(is_file_or_folder_path(file_path), 'file')
+        self.assertNotEqual(is_file_or_folder_path(file_path), 'folder')
+        self.assertEqual(is_file_or_folder_path(PDF_ASSETS_PATH), 'folder')
+        self.assertNotEqual(is_file_or_folder_path(PDF_ASSETS_PATH), 'file')
         self.assertRaises(ValueError, is_file_or_folder_path, os.path.join(PDF_ASSETS_PATH, '//EN.json'))
-        
+
     def test_get_file_or_folder_size(self):
         self.assertGreater(get_file_size(file_path), (0, 'BYTES'))
         self.assertGreater(get_folder_size(PDF_ASSETS_PATH), (0, 'BYTES'))
 
-        
+
 class Test_convert_and_format_functions(unittest.TestCase):
-    
+
     def test_convert_functions(self):
         self.assertEqual(convert_bytes_to_human_readable_size_unit(12345), (12.06, 'KB'))
-        self.assertEqual(convert_date_with_foreign_month_name('2022', 'feb', '21'), datetime.datetime(2022, 2, 21, 0, 0))
-        
+        self.assertEqual(convert_date_with_foreign_month_name('2022', 'feb', '21'),
+                         datetime.datetime(2022, 2, 21, 0, 0))
+
     def test_format_functions(self):
         self.assertEqual(format_snake_case_to_human_upper_case('hello_world'), 'Hello World')
         self.assertEqual(format_amount_to_human_string('120050.10', 'EN', '€'), '€120,050.10 ')
         self.assertEqual(format_amount_to_human_string('120050.10', 'FR', '$'), '120,050.10 $')
-        
-        
+
+
 class Test_split_and_replace_functions(unittest.TestCase):
-    
+
     def test_split_functions(self):
-        self.assertEqual(split_array([1,2,3,4,5,6,7,8,9,10], 4), [[1, 2, 3], [4, 5, 6], [7, 8], [9, 10]])
-        self.assertEqual(list(split_date_range('2015-01-01', '2015-02-28', 4)),['2015-01-01', '2015-01-15', '2015-01-30', '2015-02-13', '2015-02-28'])
+        self.assertEqual(split_array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 4), [[1, 2, 3], [4, 5, 6], [7, 8], [9, 10]])
+        self.assertEqual(list(split_date_range('2015-01-01', '2015-02-28', 4)),
+                         ['2015-01-01', '2015-01-15', '2015-01-30', '2015-02-13', '2015-02-28'])
         self.assertEqual(rreplace('anna@lox.com', 'n', '', 1), 'ana@lox.com')
 
+
 class Test_decorators(unittest.TestCase):
-    
+
     def test_perf_decorator(self):
         @Perf
         def perf_decor(x):
-            return x*2
+            return x * 2
+
         self.assertGreater(perf_decor(2), 0)
-        


### PR DESCRIPTION
Most advanced SQL users strongly favor use of [SQL parameterization](https://cloud.google.com/bigquery/docs/parameterized-queries), which is not an option for the current `select` function that only accepts f-strings. [In the words of PostgreSQL developers](https://www.psycopg.org/docs/usage.html):

> Warning Never, never, NEVER use Python string concatenation (+) or string parameters interpolation (%) to pass variables to a SQL query string. Not even at gunpoint.