### PR TITLE
add SuccessFeeHistory table in LoxData schemas

### DIFF
--- a/lox_services/persistence/database/schemas/LoxData/SuccessFeeHistory.sql
+++ b/lox_services/persistence/database/schemas/LoxData/SuccessFeeHistory.sql
@@ -1,0 +1,8 @@
+LoxData.SuccessFeeHistory
+(
+    company STRING NOT NULL,
+    success_fee_refund INT64 NOT NULL,
+    inserter_email STRING NOT NULL,
+    insert_datetime DATETIME NOT NULL,
+    update_datetime DATETIME
+)


### PR DESCRIPTION
Nothing crazy, just adding a schema for success fee history.
It is linked to a [PR](https://github.com/Lox-Solution/LoxPlatform/pull/21) on the website.

cf [Asana task](https://app.asana.com/0/1203672928258094/1203672928258113/f)