### PR TITLE
Refactor enumerated constants to use UPPERCASE_SNAKECASE.

### DIFF
--- a/lox_services/persistence/database/push_invoices_data.py
+++ b/lox_services/persistence/database/push_invoices_data.py
@@ -44,7 +44,7 @@ def push_run_to_database(run_output_folder, carrier, company, account_number_inp
         
     list_files_to_push: List[Tuple[pd.DataFrame, Enum]] = []
     
-    invoice_path = os.path.join(run_output_folder, Files.invoices.value)
+    invoice_path = os.path.join(run_output_folder, Files.INVOICES.value)
     if os.path.exists(invoice_path):
         #Read the invoice file and check the datetime format
         df_invoice: pd.DataFrame = pd.read_csv(invoice_path, infer_datetime_format = date_format, header=0,dtype={"postal_code_reciever" : str})
@@ -62,7 +62,7 @@ def push_run_to_database(run_output_folder, carrier, company, account_number_inp
             )
     
     # Prepare deliveries data
-    deliveries_path = os.path.join(run_output_folder,account_number_input, Files.deliveries.value)
+    deliveries_path = os.path.join(run_output_folder,account_number_input, Files.DELIVERIES.value)
     if os.path.exists(deliveries_path):
         #Read the delivery file and check the datetime format
         df_deliveries: pd.DataFrame = pd.read_csv(
@@ -88,7 +88,7 @@ def push_run_to_database(run_output_folder, carrier, company, account_number_inp
             )
             
         
-    refunds_path = os.path.join(run_output_folder, account_number_input,Files.refunds.value)
+    refunds_path = os.path.join(run_output_folder, account_number_input,Files.REFUNDS.value)
     # Prepare refunds data
     if os.path.exists(refunds_path):
         #Read the refund file and check the datetime format

--- a/lox_services/persistence/database/query_handlers.py
+++ b/lox_services/persistence/database/query_handlers.py
@@ -59,7 +59,7 @@ def raw_query(
 
     os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = os.path.join(SERVICE_ACCOUNT_PATH)
     if print_query:
-        print(gpy.colorize(query, Colors.Magenta))
+        print(gpy.colorize(query, Colors.MAGENTA))
 
     bigquery_client = Client()
 

--- a/lox_services/utils/decorators.py
+++ b/lox_services/utils/decorators.py
@@ -17,10 +17,10 @@ def Perf(function: Callable):
     """Prints the performance of the decorated function."""
     def wrapper(*args, **kwargs):
         start_time = perf_counter()
-        print(colorize(f"Start of function '{function.__name__}' : {datetime.now()}",Colors.Yellow))
+        print(colorize(f"Start of function '{function.__name__}' : {datetime.now()}",Colors.YELLOW))
         ret = function(*args, **kwargs)
         end_time = perf_counter()
-        print(colorize(f"Function '{function.__name__}' took {round(end_time-start_time,2)}secs to execute.",Colors.Yellow))
+        print(colorize(f"Function '{function.__name__}' took {round(end_time-start_time,2)}secs to execute.",Colors.YELLOW))
         return ret
     
     return wrapper

--- a/lox_services/utils/enums.py
+++ b/lox_services/utils/enums.py
@@ -1,21 +1,23 @@
-from enum import Enum
+from enum import Enum, IntEnum
 
 
-class Colors(Enum):
+class Colors(IntEnum):
     """Enumeration that stores some colors."""
+
     # pylint: disable=invalid-name
-    Black = 30
-    Red = 31
-    Green = 32
-    Yellow = 33
-    Blue = 34
-    Magenta = 35
-    Cyan = 36
-    White = 37
+    BLACK = 30
+    RED = 31
+    GREEN = 32
+    YELLOW = 33
+    BLUE = 34
+    MAGENTA = 35
+    CYAN = 36
+    WHITE = 37
 
 
-class SIZE_UNIT(Enum):
+class SIZE_UNIT(IntEnum):
     """Enumeration of computer size units."""
+
     BYTES = 1
     KB = 2
     MB = 3
@@ -23,37 +25,37 @@ class SIZE_UNIT(Enum):
     TB = 5
 
 
-class Files(Enum):
-    invoices = "invoices.csv"
-    deliveries = "deliveries.csv"
-    deliveries_not_working = "deliveries_not_working.csv"
-    refunds = "refunds.csv"
-    claims = "claims.csv"
-    contract = "contract.csv"
-    refunds_label_not_used = 'refunds_label_not_used.csv'
-
+class Files(str, Enum):
+    INVOICES = "invoices.csv"
+    DELIVERIES = "deliveries.csv"
+    DELIVERIES_NOT_WORKING = "deliveries_not_working.csv"
+    REFUNDS = "refunds.csv"
+    CLAIMS = "claims.csv"
+    CONTRACT = "contract.csv"
+    REFUNDS_LABEL_NOT_USED = "refunds_label_not_used.csv"
 
 
 class BQParameterType(str, Enum):
     """
     Types of parameter which can be used in parameterized query.
     """
+
     # Sequence types
     ARRAY = "ARRAY"
     STRUCT = "STRUCT"
     GEOGRAPHY = "GEOGRAPHY"
     JSON = "JSON"
-    
+
     # Scalar types
     BIGNUMERIC = "BIGNUMERIC"
     BOOL = "BOOL"
     BYTES = "BYTES"
-    DATE = "DATE"	
-    DATETIME = "DATETIME"	
+    DATE = "DATE"
+    DATETIME = "DATETIME"
     FLOAT64 = "FLOAT64"
     INT64 = "INT64"
     INTERVAL = "INTERVAL"
-    NUMERIC = "NUMERIC"	
+    NUMERIC = "NUMERIC"
     STRING = "STRING"
     TIME = "TIME"
     TIMESTAMP = "TIMESTAMP"

--- a/lox_services/utils/general_python.py
+++ b/lox_services/utils/general_python.py
@@ -20,17 +20,17 @@ def colorize(string: str, color: Colors):
 
 def print_info(string: str):
     """Format a string to error style."""
-    print(colorize(string, Colors.Yellow))
+    print(colorize(string, Colors.YELLOW))
 
 
 def print_error(string: str):
     """Format a string to error style."""
-    print(colorize(string, Colors.Red))
+    print(colorize(string, Colors.RED))
 
 
 def print_success(string: str):
     """Format a string to a success style."""
-    print(colorize(string, Colors.Green))
+    print(colorize(string, Colors.GREEN))
 
 
 def print_step(step):
@@ -43,7 +43,7 @@ f"""
     | |   / _ \ \/ /
     | |__| (_) >  <      STEP {step}
     |_____\___/_/\_\\
-""",Colors.Blue))
+""",Colors.BLUE))
 
 
 FileOrFolder = Literal["file","folder"]


### PR DESCRIPTION
[By convention, constants (enumerated or not) are written in UPPERCASE_SNAKECASE](https://peps.python.org/pep-0008/#constants). Using idiosyncratic conventions makes the codebase very hard for me to read personally:

    Constants are usually defined on a module level and written in all capital letters with underscores separating words. Examples include MAX_OVERFLOW and TOTAL.