### PR TITLE
Temporary GBQ table creation utility

### DIFF
--- a/tests/persistence/database.py
+++ b/tests/persistence/database.py
@@ -1,0 +1,33 @@
+import os
+import unittest
+import json
+from datetime import datetime, timedelta, timezone
+
+import pandas as pd
+from google.cloud.bigquery import Client, DatasetReference
+
+from lox_services.persistence.config import SERVICE_ACCOUNT_PATH
+from lox_services.persistence.database.utils import make_temporary_table
+
+
+class TestDatabaseFunctions(unittest.TestCase):
+
+    def test_make_temporary_table(self):
+        os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = SERVICE_ACCOUNT_PATH
+        with open(SERVICE_ACCOUNT_PATH, "r", encoding="utf-8") as file:
+            project_id = json.load(file)["project_id"]
+        client = Client()
+
+        make_temporary_table(
+            pd.util.testing.makeDataFrame(),
+            project_id,
+            "Mapping",
+            "UnitTest",
+        )
+
+        table_ref = DatasetReference(project_id, "Mapping").table("UnitTest")
+        table_ref = client.get_table(table_ref)
+        self.assertLess(
+            (datetime.now(timezone.utc) + timedelta(hours=1)) - table_ref.expires,
+            timedelta(seconds=1),
+        )

--- a/tests/persistence/test_persistence.py
+++ b/tests/persistence/test_persistence.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+import json
 from datetime import datetime, timedelta, timezone
 
 import numpy as np
@@ -9,44 +10,59 @@ from pandas.testing import assert_frame_equal
 
 from lox_services.persistence.config import SERVICE_ACCOUNT_PATH
 from lox_services.persistence.database.utils import (
-    equal_condition_handle_none_value, format_datetime, format_time,
-    generate_id, make_temporary_table, replace_nan_with_none_in_dataframe)
+    equal_condition_handle_none_value,
+    format_datetime,
+    format_time,
+    generate_id,
+    make_temporary_table,
+    replace_nan_with_none_in_dataframe,
+)
 
 label = None
-account = '123456'
-mock_df = pd.DataFrame(np.array([['1', np.NaN, None], [ '5', '6', np.NaN], [ '8', '9', np.NaN]]), columns=['a', 'b', 'c'])
+account = "123456"
+mock_df = pd.DataFrame(
+    np.array([["1", np.NaN, None], ["5", "6", np.NaN], ["8", "9", np.NaN]]),
+    columns=["a", "b", "c"],
+)
 df = replace_nan_with_none_in_dataframe(mock_df)
-mock_df_out = pd.DataFrame(np.array([['1', None, None], [ '5', '6', None], [ '8', '9', None]]), columns=['a', 'b', 'c'])
+mock_df_out = pd.DataFrame(
+    np.array([["1", None, None], ["5", "6", None], ["8", "9", None]]),
+    columns=["a", "b", "c"],
+)
+
 
 class TestDatabaseFunctions(unittest.TestCase):
-    
     def test_utils_functions(self):
-        self.assertEqual(generate_id(['invoice', 'date', 'amount']),'invoice_date_amount')
+        self.assertEqual(
+            generate_id(["invoice", "date", "amount"]), "invoice_date_amount"
+        )
         self.assertRaises(Exception, generate_id, [])
-        self.assertEqual(format_time('21:00'),'21:00:00')
-        self.assertEqual(format_datetime('12-12-2020', '12:00'),'12-12-2020T12:00')
-        self.assertEqual(equal_condition_handle_none_value("label", label), 'label is null')
-        self.assertEqual(equal_condition_handle_none_value("account", account), 'account = "123456"')
-        assert_frame_equal(mock_df,mock_df_out)
+        self.assertEqual(format_time("21:00"), "21:00:00")
+        self.assertEqual(format_datetime("12-12-2020", "12:00"), "12-12-2020T12:00")
+        self.assertEqual(
+            equal_condition_handle_none_value("label", label), "label is null"
+        )
+        self.assertEqual(
+            equal_condition_handle_none_value("account", account), 'account = "123456"'
+        )
+        assert_frame_equal(mock_df, mock_df_out)
 
     def test_make_temporary_table(self):
         os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = SERVICE_ACCOUNT_PATH
+        with open(SERVICE_ACCOUNT_PATH, "r", encoding="utf-8") as file:
+            table_name = json.load(file)["project_id"]
         client = Client()
 
         make_temporary_table(
             pd.util.testing.makeDataFrame(),
-            "developmentproject-269810",
+            table_name,
             "Mapping",
             "UnitTest",
         )
 
-        table_ref = DatasetReference("developmentproject-269810", "Mapping").table(
-            "UnitTest"
-        )
+        table_ref = DatasetReference(table_name, "Mapping").table("UnitTest")
         table_ref = client.get_table(table_ref)
         self.assertLess(
             (datetime.now(timezone.utc) + timedelta(hours=1)) - table_ref.expires,
             timedelta(seconds=1),
         )
-
-        

--- a/tests/persistence/test_persistence.py
+++ b/tests/persistence/test_persistence.py
@@ -50,17 +50,17 @@ class TestDatabaseFunctions(unittest.TestCase):
     def test_make_temporary_table(self):
         os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = SERVICE_ACCOUNT_PATH
         with open(SERVICE_ACCOUNT_PATH, "r", encoding="utf-8") as file:
-            table_name = json.load(file)["project_id"]
+            project_id = json.load(file)["project_id"]
         client = Client()
 
         make_temporary_table(
             pd.util.testing.makeDataFrame(),
-            table_name,
+            project_id,
             "Mapping",
             "UnitTest",
         )
 
-        table_ref = DatasetReference(table_name, "Mapping").table("UnitTest")
+        table_ref = DatasetReference(project_id, "Mapping").table("UnitTest")
         table_ref = client.get_table(table_ref)
         self.assertLess(
             (datetime.now(timezone.utc) + timedelta(hours=1)) - table_ref.expires,

--- a/tests/persistence/test_persistence.py
+++ b/tests/persistence/test_persistence.py
@@ -1,20 +1,14 @@
-import os
 import unittest
-import json
-from datetime import datetime, timedelta, timezone
 
 import numpy as np
 import pandas as pd
-from google.cloud.bigquery import Client, DatasetReference
 from pandas.testing import assert_frame_equal
 
-from lox_services.persistence.config import SERVICE_ACCOUNT_PATH
 from lox_services.persistence.database.utils import (
     equal_condition_handle_none_value,
     format_datetime,
     format_time,
     generate_id,
-    make_temporary_table,
     replace_nan_with_none_in_dataframe,
 )
 
@@ -46,23 +40,3 @@ class TestDatabaseFunctions(unittest.TestCase):
             equal_condition_handle_none_value("account", account), 'account = "123456"'
         )
         assert_frame_equal(mock_df, mock_df_out)
-
-    def test_make_temporary_table(self):
-        os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = SERVICE_ACCOUNT_PATH
-        with open(SERVICE_ACCOUNT_PATH, "r", encoding="utf-8") as file:
-            project_id = json.load(file)["project_id"]
-        client = Client()
-
-        make_temporary_table(
-            pd.util.testing.makeDataFrame(),
-            project_id,
-            "Mapping",
-            "UnitTest",
-        )
-
-        table_ref = DatasetReference(project_id, "Mapping").table("UnitTest")
-        table_ref = client.get_table(table_ref)
-        self.assertLess(
-            (datetime.now(timezone.utc) + timedelta(hours=1)) - table_ref.expires,
-            timedelta(seconds=1),
-        )


### PR DESCRIPTION
During the process of refactoring UPS claiming procedure, I figured out that the script was impossible to parallelize as-is, because it was trying to overwrite the same SQL table. As 1) creating a temporary table from Python requires some boilerplate and 2) this code for sure will be reused in the future, I extracted this section of code and added unit tests for it.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203937504251249