### PR TITLE
Add a utility function for concise .search().group() call for compiled regular expressions

### DIFF
--- a/lox_services/utils/regex.py
+++ b/lox_services/utils/regex.py
@@ -1,0 +1,52 @@
+import re
+from typing import Any, Callable, Optional
+
+
+def make_get_first(
+    regex_string: str, process_match: Optional[Callable] = None
+) -> Callable[[str], Any]:
+    """
+    Factory function that returns a callable that takes a string as an argument and
+    returns the first match for a given regular expression pattern within that string.
+
+    Args:
+    regex_string (str): A regular expression pattern to match against strings.
+    process_match (Optional[Callable]): A function that takes the match as input and returns a processed result
+    (say, to coerce a data type). If provided, the returned callable will apply this function to the match
+    before returning it.
+
+    Returns:
+    A callable that takes a string argument and returns the first match of the pattern
+    within the string.
+
+    Example usage:
+
+    >>>import re
+    >>>get_first_digit = make_get_first(r"\d+")
+    >>>print(get_first_digit('abc 123 def 456'))  # Output: '123'
+
+    """
+    pattern = re.compile(regex_string)
+
+    def get_first(string: str) -> Any:
+        """
+        This function takes a string as an argument and returns the first match for the pattern within
+        that string.
+
+        Args:
+        string (str): A string to search for a match to the pattern.
+
+        Returns:
+        The first match of the pattern within the string.
+        """
+        try:
+            match = pattern.search(string).group()
+        except AttributeError as e:
+            raise AttributeError(
+                "Unable to find any value matching the regular expression"
+            ) from e
+        if process_match is not None:
+            match = process_match(match)
+        return match
+
+    return get_first

--- a/tests/utils/test_regex.py
+++ b/tests/utils/test_regex.py
@@ -1,0 +1,95 @@
+import re
+import unittest
+
+from lox_services.utils.regex import make_get_first
+
+
+class TestMakeGetFirst(unittest.TestCase):
+    def test_get_first_alpha(self) -> None:
+        get_first_alpha = make_get_first(r"[a-zA-Z]+")
+        result = get_first_alpha("abc123def456")
+        self.assertEqual(result, "abc")
+
+    def test_get_first_email(self) -> None:
+        get_first_email = make_get_first(
+            r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b"
+        )
+        result = get_first_email(
+            "Please contact me at test@example.com for further assistance."
+        )
+        self.assertEqual(result, "test@example.com")
+
+    def test_get_first_phone(self) -> None:
+        get_first_phone = make_get_first(r"\b\d{3}-\d{3}-\d{4}\b")
+        result = get_first_phone("Call me at 123-456-7890 for any queries.")
+        self.assertEqual(result, "123-456-7890")
+
+    def test_get_first_url(self) -> None:
+        get_first_url = make_get_first(r"\b(?:https?://)?(?:www\.)?\w+\.\w+\.\w+\b")
+        result = get_first_url(
+            "Visit our website at https://www.example.com for more information."
+        )
+        self.assertEqual(result, "https://www.example.com")
+
+    def test_get_first_match(self) -> None:
+        # Test with a valid regex pattern and a string containing a match
+        get_first_digit = make_get_first(r"\d+")
+        result = get_first_digit("abc 123 def 456")
+        self.assertEqual(result, "123")
+
+    def test_get_first_match_with_process_match(self) -> None:
+        # Test with a valid regex pattern, a string containing a match, and a process_match function
+        def process_match(match):
+            return int(match)
+
+        get_first_digit = make_get_first(r"\d+", process_match=process_match)
+        result = get_first_digit("abc 123 def 456")
+        self.assertEqual(result, 123)
+
+    def test_get_first_no_match(self) -> None:
+        # Test with a valid regex pattern and a string with no match
+        get_first_digit = make_get_first(r"\d+")
+        with self.assertRaises(AttributeError):
+            _ = get_first_digit("abc def")
+
+    def test_get_first_no_match_with_process_match(self) -> None:
+        # Test with a valid regex pattern, a string with no match, and a process_match function
+        def process_match(match):
+            return int(match)
+
+        get_first_digit = make_get_first(r"\d+", process_match=process_match)
+        with self.assertRaises(AttributeError):
+            _ = get_first_digit("abc def")
+
+    def test_get_first_empty_string(self) -> None:
+        # Test with an empty string as input
+        get_first_digit = make_get_first(r"\d+")
+        with self.assertRaises(AttributeError):
+            _ = get_first_digit("")
+
+    def test_get_first_empty_string_with_process_match(self) -> None:
+        # Test with an empty string as input and a process_match function
+        def process_match(match):
+            return int(match)
+
+        get_first_digit = make_get_first(r"\d+", process_match=process_match)
+        with self.assertRaises(AttributeError):
+            _ = get_first_digit("")
+
+    def test_get_first_invalid_regex(self) -> None:
+        # Test with an invalid regex pattern
+        with self.assertRaises(re.error):
+            get_first_digit = make_get_first(r"(\d+")
+            _ = get_first_digit("abc 123 def 456")
+
+    def test_get_first_invalid_process_match(self) -> None:
+        # Test with an invalid process_match function
+        get_first_digit = make_get_first(r"\d+")
+        with self.assertRaises(TypeError):
+            _ = get_first_digit(
+                "abc 123 def 456", process_match="invalid_function"  # NOQA
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The alternative would be slightly more verbose:

```
FIND_DIGITS: Final = re.compile(r"\d+")
value = FIND_DIGITS.search(text).group()

```
vs

```
find_digits = make_get_first(r"\d+")
value = find_digits(text)
```

Example use can be found here - https://github.com/Lox-Solution/Main-Algorithms/pull/468