### PR TITLE
Handle wrong chrome version error

### DIFF
--- a/lox_services/scraping/chromedriver.py
+++ b/lox_services/scraping/chromedriver.py
@@ -141,4 +141,15 @@ def run_chromedriver(
     """
     if get_env_variable("ENVIRONMENT") == "production":
         shutdown_current_instances()
-    return init_chromedriver(download_folder, size_length, size_width, version)
+    try:
+        return init_chromedriver(download_folder, size_length, size_width, version)
+    except WebDriverException as e:
+        error = str(e.args[0]).lower()
+        if "chromedriver only supports chrome version" in error:
+            downloaded_version = error.split("current browser version is ")[1].split(
+                "."
+            )[0]
+            return init_chromedriver(
+                download_folder, size_length, size_width, int(downloaded_version)
+            )
+        raise e


### PR DESCRIPTION
if the selenium crashes due to chromedriver version, it will look for the downloaded version and run chromedriver with this one.