### PR TITLE
Colissimo: Allow specific country translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,3 +45,4 @@
 1.0.2 Hotfix on python versions required
 1.0.3 Align the requirements and the setup packages
 1.0.4 Hotfix resizing chromedriver
+1.0.5 Hotfix allowing Colissimo specific translation

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="lox_services",
-    version="1.0.4",
+    version="1.0.5",
     author="Lox Solution",
     author_email="natasa.zekic@loxsolution.com",
     description="A package with Lox services",


### PR DESCRIPTION
Tested with:
# Test DataFrame
data = {
    "country_code_receiver": ["US", "HO", "FR", "DE", "HO", "IT"],
    "country_code_sender": ["HO", "IT", "HO", "US", "DE", "FR"],
    "carrier": ["ups", "colissimo", "dhl", "fedex", "colissimo", "colissimo"],
}

df_test = pd.DataFrame(data)
print("Original DataFrame:")
print(df_test)

# Applying translate_country_codes
df_transformed = translate_country_codes(
    df_test, ["country_code_receiver", "country_code_sender"]
)
print("\nDataFrame after translate_country_codes:")
print(df_transformed)
