### PR TITLE
Remove country code validation 

### DIFF
--- a/lox_services/persistence/database/push_invoices_data.py
+++ b/lox_services/persistence/database/push_invoices_data.py
@@ -56,8 +56,7 @@ def process_df(
 
 
 def process_postal_and_country_cols(df: pd.DataFrame) -> pd.DataFrame:
-    """Remove faux floating point conversion and validate country code columns in the
-    dataframe."""
+    """Remove faux floating point conversion in the dataframe."""
     postal_code_cols = df.columns[
         df.columns.isin({"postal_code_receiver", "postal_code_sender"})
     ].tolist()
@@ -66,7 +65,6 @@ def process_postal_and_country_cols(df: pd.DataFrame) -> pd.DataFrame:
         lambda col: col.str.removesuffix(".0")
     )
 
-    validate_country_code(df, ["country_code_receiver", "country_code_sender"])
     return df
 
 

--- a/lox_services/persistence/database/utils.py
+++ b/lox_services/persistence/database/utils.py
@@ -41,9 +41,6 @@ def quality_check_package_info(df: pd.DataFrame) -> None:
         if df[column].isnull().any():
             raise ValueError(f"Column {column} contains null values")
 
-    # Check that the country codes are valid, will raise an exception if not
-    validate_country_code(df, ["country_code_receiver", "country_code_sender"])
-
 
 def generate_id(columns: list) -> str:
     """Generates an id with column names


### PR DESCRIPTION
Country code validation works well, unfortunately not all carriers respect the good country code. As we are not using the country codes, we decided to deactivate this check to avoid crashes