### PR TITLE
stop returning the entire table in remove duplicate package information

### DIFF
--- a/lox_services/persistence/database/remove_duplicates.py
+++ b/lox_services/persistence/database/remove_duplicates.py
@@ -376,7 +376,7 @@ def remove_duplicate_package_information(dataframe: pd.DataFrame) -> pd.DataFram
             distinct carrier || company || tracking_number AS existing_entry
 
         FROM CarrierData.PackageInformation
-        WhERE tracking_number IN UNNEST(@tracking_numbers)
+        WHERE tracking_number IN UNNEST(@tracking_numbers)
     """
     already_saved_entries = select(
         sql_query,

--- a/lox_services/persistence/database/remove_duplicates.py
+++ b/lox_services/persistence/database/remove_duplicates.py
@@ -370,19 +370,26 @@ def remove_duplicate_currency_conversion(dataframe: pd.DataFrame) -> pd.DataFram
 
 def remove_duplicate_package_information(dataframe: pd.DataFrame) -> pd.DataFrame:
     """Removes already saved package information dataframe"""
+    tns = dataframe["tracking_number"].unique().to_list()
     sql_query = """
         SELECT
             distinct carrier || company || tracking_number AS existing_entry
 
         FROM CarrierData.PackageInformation
+        WhERE tracking_number IN UNNEST(@tracking_numbers)
     """
-    already_saved_entries = select(sql_query, False)["existing_entry"].to_list()
+    already_saved_entries = select(
+        sql_query,
+        False,
+        parameters=(("tracking_numbers", BQParameterType.STRING, tns),),
+    )["existing_entry"].to_list()
     if already_saved_entries:
+        dataframe["concat_values"] = (
+            dataframe["carrier"].astype(str)
+            + dataframe["company"].astype(str)
+            + dataframe["tracking_number"].astype(str)
+        )
         dataframe = dataframe.loc[
-            ~(
-                dataframe["carrier"]
-                + dataframe["company"]
-                + dataframe["tracking_number"]
-            ).isin(already_saved_entries)
-        ]
+            ~dataframe["concat_values"].isin(already_saved_entries)
+        ].drop(columns=["concat_values"])
     return dataframe


### PR DESCRIPTION
I'm almost sure it's the cause of the -9 error status code we got. 
 