### PR TITLE
When checking if we already have a tracking number, select all reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,3 +52,4 @@
 1.2.1 Optimize Query to remove duplicates on package information, add default original currency columns
 1.2.2 fix package information remove duplicates
 1.2.3 Make sure virtual display wraps all functions
+1.2.4 Include all reason refunds in check duplicates

--- a/lox_services/persistence/database/remove_duplicates.py
+++ b/lox_services/persistence/database/remove_duplicates.py
@@ -71,7 +71,6 @@ def remove_duplicate_refunds(dataframe: pd.DataFrame) -> pd.DataFrame:
     carrier = dataframe.iloc[0]["carrier"]
     company = dataframe.iloc[0]["company"]
     dataframe["reason_refund"] = dataframe.reason_refund.astype(str)
-    reason_refunds = dataframe["reason_refund"].unique().tolist()
     reason_refunds = list(
         set(
             dataframe["reason_refund"].unique().tolist()

--- a/lox_services/persistence/database/remove_duplicates.py
+++ b/lox_services/persistence/database/remove_duplicates.py
@@ -72,6 +72,12 @@ def remove_duplicate_refunds(dataframe: pd.DataFrame) -> pd.DataFrame:
     company = dataframe.iloc[0]["company"]
     dataframe["reason_refund"] = dataframe.reason_refund.astype(str)
     reason_refunds = dataframe["reason_refund"].unique().tolist()
+    reason_refunds = list(
+        set(
+            dataframe["reason_refund"].unique().tolist()
+            + ["Damaged", "Lost", "Delivery Dispute"]
+        )
+    )
 
     dataframe["tracking_number"] = dataframe.tracking_number.astype(str)
     tracking_numbers = dataframe["tracking_number"].tolist()

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="lox_services",
-    version="1.2.3",
+    version="1.2.4",
     author="Lox Solution",
     author_email="natasa.zekic@loxsolution.com",
     description="A package with Lox services",


### PR DESCRIPTION
Currently, if we add a Lost tracking number, we are not retrieving Damaged and Delivery Dispute from the db, which can create doubles on these reason refunds